### PR TITLE
added getGroup() to CheckInterface

### DIFF
--- a/Check/Check.php
+++ b/Check/Check.php
@@ -6,12 +6,20 @@ use Liip\Monitor\Result\CheckResult;
 
 abstract class Check implements CheckInterface
 {
-     /**
+    /**
      * {@inheritdoc}
      */
     public function getName()
     {
         return get_called_class();
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function getGroup()
+    {
+        return 'default';
     }
 
     /**

--- a/Check/CheckChain.php
+++ b/Check/CheckChain.php
@@ -56,4 +56,38 @@ final class CheckChain
 
         return $this->checks[$id];
     }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function getChecksByGroup($name)
+    {
+        $checks = array();
+
+        foreach ($this->checks as $id => $check) {
+            if ($check->getGroup() === $name) {
+                $checks[] = $id;
+            }
+        }
+
+        return $checks;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGroups()
+    {
+        $groups = array();
+
+        foreach ($this->checks as $check) {
+
+            if (!in_array($check->getGroup(), $groups)) {
+                $groups[] = $check->getGroup();
+            }
+        }
+
+        return $groups;
+    }
 }

--- a/Check/CheckInterface.php
+++ b/Check/CheckInterface.php
@@ -7,10 +7,15 @@ interface CheckInterface
     /**
      * @return \Liip\Monitor\Result\CheckResult
      */
-    function check();
+    public function check();
 
     /**
      * @return string
      */
-    function getName();
+    public function getName();
+
+    /**
+     * @return string
+     */
+    public function getGroup();
 }

--- a/Check/Runner.php
+++ b/Check/Runner.php
@@ -2,6 +2,7 @@
 
 namespace Liip\Monitor\Check;
 
+use Liip\Monitor\Result\CheckResult;
 class Runner
 {
     protected $chain;
@@ -40,6 +41,28 @@ class Runner
         $results = array();
         foreach ($this->chain->getChecks() as $id => $checkService) {
             $results[$id] = $this->runCheck($checkService);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array
+     */
+    public function runAllChecksByGroup()
+    {
+        $results = array();
+        $groups = $this->chain->getGroups();
+
+        foreach ($groups as $group) {
+            $results[$group] = CheckResult::OK;
+        }
+
+        foreach ($this->chain->getChecks() as $id => $checkService) {
+            $check = $this->runCheck($checkService);
+            if ($check->getStatus() > $results[$checkService->getGroup()]) {
+                $results[$checkService->getGroup()] = $check;
+            }
         }
 
         return $results;

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Get the composer installer if its not yet installed on your system and run ``upd
     # install dependencies
     curl -s http://getcomposer.org/installer | php
     php composer.phar update liip/monitor
+    
+    
+## Check groups ##
+
+Checks can be grouped by implementing the `getGroup` method of the `CheckInterface`.
+By grouping checks it's possible to implement end-user status pages which provide feedback
+but hide implementation details, similar to [status.github.com](http://status.github.com).  
 
 ## Available Health Checks ##
 


### PR DESCRIPTION
The usecase for having check-groups is if you want to expose a status page to end users, but don't want to show all the details like `Symfony version check` / `Redis check` etc. 

Similar to https://status.github.com/ 

Putting your checks in groups could help with building such pages.
